### PR TITLE
clFFT and clBLAS

### DIFF
--- a/src/iterative.c
+++ b/src/iterative.c
@@ -38,7 +38,7 @@
 
 #ifdef OCL_BLAS
 #	include "oclcore.h"
-#	include <clAmdBlas.h> //external library from AMD
+#	include <clBLAS.h> //external library
 #endif
 
 // SEMI-GLOBAL VARIABLES
@@ -522,12 +522,12 @@ ITER_FUNC(BiCG_CS)
 			return;
 		case PHASE_INIT: 
 #ifdef OCL_BLAS
-			D("clAmdBlasSetup started");
-			CL_CH_ERR(clAmdBlasSetup());
+			D("clblasSetup started");
+			CL_CH_ERR(clblasSetup());
 #	ifdef DEBUGFULL
 			cl_uint major,minor,patch;
-			CL_CH_ERR(clAmdBlasGetVersion(&major,&minor,&patch));
-			D("clAmdBlas library version - %u.%u.%u",major,minor,patch);
+			CL_CH_ERR(clblasGetVersion(&major,&minor,&patch));
+			D("clBLAS library version - %u.%u.%u",major,minor,patch);
 #	endif
 			bufupload=false;
 			CL_CH_ERR(clEnqueueWriteBuffer(command_queue,bufpvec,CL_FALSE,0,sizeof(doublecomplex)*local_nRows,pvec,0,
@@ -547,7 +547,7 @@ ITER_FUNC(BiCG_CS)
 			 */
 			CREATE_CL_BUFFER(bufro_new,CL_MEM_READ_WRITE,sizeof(doublecomplex),NULL);
 			CREATE_CL_BUFFER(bufmu,CL_MEM_READ_WRITE,sizeof(doublecomplex),NULL);
-			CL_CH_ERR(clAmdBlasZdotu(local_nRows,bufro_new,0,bufrvec,0,1,bufrvec,0,1,buftmp,1,&command_queue,0,NULL,
+			CL_CH_ERR(clblasZdotu(local_nRows,bufro_new,0,bufrvec,0,1,bufrvec,0,1,buftmp,1,&command_queue,0,NULL,
 				NULL));
 			CL_CH_ERR(clEnqueueReadBuffer(command_queue,bufro_new,CL_TRUE,0,sizeof(doublecomplex),&ro_new,0,NULL,NULL));
 #else
@@ -571,9 +571,9 @@ ITER_FUNC(BiCG_CS)
 				// p_k=beta_k-1*p_k-1+r_k-1
 #ifdef OCL_BLAS
 				cl_double2 clbeta = {.s={creal(beta),cimag(beta)}};
-				CL_CH_ERR(clAmdBlasZscal(local_nRows,clbeta,bufpvec,0,1,1,&command_queue,0,NULL,NULL));
+				CL_CH_ERR(clblasZscal(local_nRows,clbeta,bufpvec,0,1,1,&command_queue,0,NULL,NULL));
 				cl_double2 clunit = {.s={1,0}};
-				CL_CH_ERR(clAmdBlasZaxpy(local_nRows,clunit,bufrvec,0,1,bufpvec,0,1,1,&command_queue,0,NULL,NULL));
+				CL_CH_ERR(clblasZaxpy(local_nRows,clunit,bufrvec,0,1,bufpvec,0,1,1,&command_queue,0,NULL,NULL));
 #else
 				nIncrem10_cmplx(pvec,rvec,beta,NULL,NULL);
 #endif
@@ -583,7 +583,7 @@ ITER_FUNC(BiCG_CS)
 			else MatVec(pvec,Avecbuffer,NULL,false,&Timing_OneIterMVP,&Timing_OneIterMVPComm);
 			// mu_k=p_k.q_k; check for mu_k!=0
 #ifdef OCL_BLAS
-			CL_CH_ERR(clAmdBlasZdotu(local_nRows,bufmu,0,bufpvec,0,1,bufAvecbuffer,0,1,buftmp,1,&command_queue,0,NULL,
+			CL_CH_ERR(clblasZdotu(local_nRows,bufmu,0,bufpvec,0,1,bufAvecbuffer,0,1,buftmp,1,&command_queue,0,NULL,
 				NULL));
 			CL_CH_ERR(clEnqueueReadBuffer(command_queue,bufmu,CL_TRUE,0,sizeof(doublecomplex),&mu,0,NULL,NULL));
 #else
@@ -597,7 +597,7 @@ ITER_FUNC(BiCG_CS)
 			// x_k=x_k-1+alpha_k*p_k
 #ifdef OCL_BLAS
 			cl_double2 clalpha = {.s={creal(alpha),cimag(alpha)}};
-			CL_CH_ERR(clAmdBlasZaxpy(local_nRows,clalpha,bufpvec,0,1,bufxvec,0,1,1,&command_queue,0,NULL,NULL));
+			CL_CH_ERR(clblasZaxpy(local_nRows,clalpha,bufpvec,0,1,bufxvec,0,1,1,&command_queue,0,NULL,NULL));
 #else
 			nIncrem01_cmplx(xvec,pvec,alpha,NULL,NULL);
 #endif
@@ -606,8 +606,8 @@ ITER_FUNC(BiCG_CS)
 #ifdef OCL_BLAS
 			cl_double2 cltemp = {.s={creal(temp),cimag(temp)}};
 			CREATE_CL_BUFFER(bufinprodRp1,CL_MEM_READ_WRITE,sizeof(double),NULL);
-			CL_CH_ERR(clAmdBlasZaxpy(local_nRows,cltemp,bufAvecbuffer,0,1,bufrvec,0,1,1,&command_queue,0,NULL,NULL));
-			CL_CH_ERR(clAmdBlasDznrm2(local_nRows,bufinprodRp1,0,bufrvec,0,1,buftmp,1,&command_queue,0,NULL,NULL));
+			CL_CH_ERR(clblasZaxpy(local_nRows,cltemp,bufAvecbuffer,0,1,bufrvec,0,1,1,&command_queue,0,NULL,NULL));
+			CL_CH_ERR(clblasDznrm2(local_nRows,bufinprodRp1,0,bufrvec,0,1,buftmp,1,&command_queue,0,NULL,NULL));
 			CL_CH_ERR(clEnqueueReadBuffer(command_queue,bufinprodRp1,CL_TRUE,0,sizeof(double),&inprodRp1,0,NULL,NULL));
 			inprodRp1=inprodRp1*inprodRp1;
 #else

--- a/src/ocl/Makefile
+++ b/src/ocl/Makefile
@@ -42,21 +42,19 @@ else # the following is only for non-sparse mode
       $(error Apple clFFT (CLFFT_APPLE) is implemented in C++, hence incompatible with NO_CPP)
     endif
   else # AMD clFFT flags
-    # Depending on a particular clAmdFft installation one may need to manually specify paths to its headers and 
+    # Depending on a particular clFFT installation one may need to manually specify paths to its headers and 
     # libraries. Path should be absolute or relative to the location of this Makefile.
     # On Windows (as in example below) it is recommended to link to *.dll instead of *.lib
     #CFLAGS  += -I"C:\Program Files (x86)\AMD\clAmdFft\include"
     #LDFLAGS += -L"C:\Program Files (x86)\AMD\clAmdFft\bin64"
   
     LDLIBS += -lclFFT
-    # former name of the library
-    #LDLIBS += -lclAmdFft.Runtime
 
-    # On Unix clAmdFft may need pthread library, which is not linked by default; if yes, uncomment the following
+    # On Unix clFFT may need pthread library, which is not linked by default; if yes, uncomment the following
     #LDLIBS += -lpthread
   
     # Uncomment the following line if you experience problems during linking, like
-    # "...libclAmdFft.Runtime.so: undefined reference to `clRetainContext@OPENCL_1.0'"
+    # "...libclFFT.so: undefined reference to `clRetainContext@OPENCL_1.0'"
     # This is caused by Nvidia OpenCL libraries on Linux (hopefully it will disappear in next releases of this library)
     # The drawback of this workaround is that a warning would appear at each execution of adda_ocl. If you don't like 
     # it, provide another libOpenCL.so (e.g. that from AMD, or better - open-source one from 
@@ -64,19 +62,17 @@ else # the following is only for non-sparse mode
     #LDFLAGS +=-Wl,--unresolved-symbols=ignore-in-shared-libs
   endif
   ifneq ($(filter OCL_BLAS,$(OPTIONS)),)
-    # Depending on a particular clAmdFft installation one may need to manually specify paths to its headers and 
+    # Depending on a particular clBLAS installation one may need to manually specify paths to its headers and 
     # libraries. Path should be absolute or relative to the location of this Makefile.
     # On Windows (as in example below) it is recommended to link to *.dll instead of *.lib
     #CFLAGS  += -I"C:\Program Files (x86)\AMD\clAmdBlas\include"
     #LDFLAGS += -L"C:\Program Files (x86)\AMD\clAmdBlas\bin64"
     
     LDLIBS += -lclBLAS
-    # former name of the library
-    #LDLIBS += -lclAmdBlas
 
     CFLAGS += -DOCL_BLAS
-    # If you have any problems during linking, see above for issues related to clAmdFft. The same solutions may work
-    # for clAmdBlas
+    # If you have any problems during linking, see above for issues related to clFFT. The same solutions may work
+    # for clBLAS
   endif
 endif
 

--- a/src/ocl/Makefile
+++ b/src/ocl/Makefile
@@ -48,7 +48,10 @@ else # the following is only for non-sparse mode
     #CFLAGS  += -I"C:\Program Files (x86)\AMD\clAmdFft\include"
     #LDFLAGS += -L"C:\Program Files (x86)\AMD\clAmdFft\bin64"
   
-    LDLIBS += -lclAmdFft.Runtime
+    LDLIBS += -lclFFT
+    # former name of the library
+    #LDLIBS += -lclAmdFft.Runtime
+
     # On Unix clAmdFft may need pthread library, which is not linked by default; if yes, uncomment the following
     #LDLIBS += -lpthread
   
@@ -67,7 +70,10 @@ else # the following is only for non-sparse mode
     #CFLAGS  += -I"C:\Program Files (x86)\AMD\clAmdBlas\include"
     #LDFLAGS += -L"C:\Program Files (x86)\AMD\clAmdBlas\bin64"
     
-    LDLIBS += -lclAmdBlas
+    LDLIBS += -lclBLAS
+    # former name of the library
+    #LDLIBS += -lclAmdBlas
+
     CFLAGS += -DOCL_BLAS
     # If you have any problems during linking, see above for issues related to clAmdFft. The same solutions may work
     # for clAmdBlas

--- a/src/oclcore.c
+++ b/src/oclcore.c
@@ -50,7 +50,7 @@ cl_mem bufXmatrix,bufmaterial,bufposition,bufcc_sqrt,bufargvec,bufresultvec,bufs
 bool bufupload=true;
 
 #ifdef OCL_BLAS
-cl_mem buftmp;  // temporary buffer for dot products and Norm (as required by clAmdBlas library)
+cl_mem buftmp;  // temporary buffer for dot products and Norm (as required by clBLAS library)
 cl_mem bufrvec; // buffer used in iterative solver
 cl_mem bufxvec; // buffer used in iterative solver
 #endif

--- a/src/param.c
+++ b/src/param.c
@@ -39,18 +39,18 @@
 #include <time.h>
 
 #ifdef CLFFT_AMD
-/* One can also include clAmdFft.h (the only recommended public header), which can be redundant, but more portable.
+/* One can also include clFFT.h (the only recommended public header), which can be redundant, but more portable.
  * However, version macros are not documented anyway (in the manual), so there seem to be no perfectly portable way to
  * obtain them.
  */
-#	include <clAmdFft.version.h>
+#	include <clFFT.version.h>
 #endif
 
 #ifdef OCL_BLAS
-/* In contrast to clAmdFft, here including main header (clAmdBlas.h) is not an option, since it doesn't include the
+/* In contrast to clFFT, here including main header (clBLAS.h) is not an option, since it doesn't include the
  * following header.
  */
-#	include <clAmdBlas.version.h>
+#	include <clBLAS.version.h>
 #endif
 
 #ifndef NO_SVNREV
@@ -1618,11 +1618,11 @@ PARSE_FUNC(V)
 #	endif
 		printf("GPU-accelerated version conforming to OpenCL standard "OCL_VERSION"\n");
 #	ifdef CLFFT_AMD
-		printf("Linked to clAmdFft version %d.%d.%d\n",clAmdFftVersionMajor,clAmdFftVersionMinor,clAmdFftVersionPatch);
+		printf("Linked to clFFT version %d.%d.%d\n",clfftVersionMajor,clfftVersionMinor,clfftVersionPatch);
 #	endif
 #	ifdef OCL_BLAS
-		printf("Linked to clAmdBlas version %d.%d.%d\n",clAmdBlasVersionMajor,clAmdBlasVersionMinor,
-			clAmdBlasVersionPatch);
+		printf("Linked to clBLAS version %d.%d.%d\n",clblasVersionMajor,clblasVersionMinor,
+			clblasVersionPatch);
 #	endif
 #elif defined(ADDA_MPI)
 		// Version of MPI standard is specified


### PR DESCRIPTION
As addressed in issue #204, AMD open-sourced its OpenCL libraries. The old version (including the library naming with "Amd" in the name and in all functions) disappered from the AMD homepage. So there is probably no need to keep the old references and namings in the adda code. This PR fixes all naming issues related to the new libraries.
