### PR TITLE
Added OpenCL compiler flags for Apple.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # This is currently empty. If you need some ignores, which are specific to your workflow (e.g. IDE), consider
 # including them into $GIT_DIR/info/exclude (in this repository) or globally into $XDG_CONFIG_HOME/git/ignore
 # See https://git-scm.com/docs/gitignore 
+.DS_Store

--- a/src/ocl/Makefile
+++ b/src/ocl/Makefile
@@ -80,8 +80,14 @@ endif
 # !!! End of control section. Everything below is not designed to be modified by user
 #=======================================================================================================================
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LDLIBS  += -framework OpenCL
+else
+    LDLIBS  += -lOpenCL
+endif
 CFLAGS  += -DOPENCL 
-LDLIBS  += -lOpenCL
+
 CSOURCE += oclcore.c oclmatvec.c
 
 ifneq ($(filter OCL_READ_SOURCE_RUNTIME,$(OPTIONS)),)

--- a/src/ocl/Makefile
+++ b/src/ocl/Makefile
@@ -82,9 +82,9 @@ endif
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	LDLIBS  += -framework OpenCL
+  LDLIBS  += -framework OpenCL
 else
-    LDLIBS  += -lOpenCL
+  LDLIBS  += -lOpenCL
 endif
 CFLAGS  += -DOPENCL 
 


### PR DESCRIPTION
### Description
Two minor changes have been implemented with this PR:
- OpenCL compiler flags for Apple macOS Catalina
- Adding `.DS_Store` to `.gitignore` to remove clutter for Apple developers.

Testing the executable provides the following result:
```shell
$ time ./adda_ocl -gpu 1
all data is saved in 'run001_sphere_g16_m1.5'
box dimensions: 16x16x16
lambda: 6.283185307   Dipoles/lambda: 15
Required relative residual norm: 1e-05
Total number of occupied dipoles: 2176
Searching for OpenCL devices
Using OpenCL device, based on Apple.
Device memory: total - , maximum object - 
Calculating Green's function (Dmatrix)
Fourier transform of Dmatrix......
Initializing clFFT
Total memory usage: 1.1 MB
OpenCL memory usage: peak total - 4.4 MB, maximum object - 1.5 MB

here we go, calc Y

CoupleConstant: 0.005259037197+1.843854148e-05i
x_0 = 0
RE_000 = 1.0000000000E+00
RE_001 = 8.4752662637E-01  + 
RE_002 = 8.2113292044E-01  + 
RE_003 = 4.2639057157E-01  + 
RE_004 = 3.0639031825E-01  + 
RE_005 = 2.2448283848E-01  + 
RE_006 = 2.2740255145E-01  - 
RE_007 = 1.5952149116E-01  + 
RE_008 = 6.1602401377E-02  + 
RE_009 = 3.5443250605E-02  + 
RE_010 = 2.9898244022E-02  + 
RE_011 = 2.4111231314E-02  + 
RE_012 = 3.8307716444E-03  + 
RE_013 = 3.0434605427E-03  + 
RE_014 = 1.3101400515E-03  + 
RE_015 = 8.2588869878E-04  + 
RE_016 = 5.0452779402E-04  + 
RE_017 = 1.1339754530E-04  + 
RE_018 = 9.3640493818E-05  + 
RE_019 = 6.8748674555E-05  + 
RE_020 = 2.2386140050E-05  + 
RE_021 = 1.5169630211E-05  + 
RE_022 = 3.1675098706E-06  + 
Cext	= 135.0449045
Qext	= 3.791149606
Cabs	= -2.047466079e-16
Qabs	= -5.747903078e-18

real	0m0.787s
user	0m0.083s
sys	0m0.036s
```

### Related issues
No issues were created prior to this PR. Changes were discussed via email.

### Types of changes
_What types of changes does your code introduce to ADDA? Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [contributing guidelines](https://github.com/adda-team/adda/blob/master/.github/CONTRIBUTING.md)
- [x] Code compiles correctly
- [x] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works. And these tests pass
- [ ] I have added/extended necessary documentation (if appropriate)

### Further comments
This is a very small change. 
On macOS `make` also cannot link against `libgfortran.a` out of the box, but I don't know how to fix that without hard-coding the gfortran directory in the makefile with `-L/<location of libgfortran.a>` and thus didn't include it in the PR.
